### PR TITLE
cfdiengine: docker file to run service into container

### DIFF
--- a/tools/docker/cfdiengine/DockerFile
+++ b/tools/docker/cfdiengine/DockerFile
@@ -1,0 +1,24 @@
+FROM dockette/stretch
+MAINTAINER pianodaemon@gmail.com
+
+RUN apt-get update
+RUN apt-get install -y python3-pyxb python3-psycopg2 python3-zeep python3-pip python3-lxml python3-reportlab python3-unidecode python3-qrcode
+RUN apt-get install -y xsltproc git
+
+# The trick is to use useradd instead of its interactive wrapper adduser
+RUN useradd -ms /bin/bash cfdiengine
+USER cfdiengine
+WORKDIR /home/cfdiengine
+
+ENV GIT_REPO_CFDIENGINE https://github.com/gmas01/erp_sumar
+
+RUN git clone $GIT_REPO_CFDIENGINE last_clonation
+RUN mv ./last_clonation/cfdiengine ./
+RUN mkdir resources
+RUN rm -rf ./last_clonation
+
+WORKDIR /home/cfdiengine/cfdiengine
+
+CMD ["python3", "run.py", "-d"]
+
+EXPOSE 10080


### PR DESCRIPTION
As of now cfdiengine shall be run as a service within a docker container
by using the following command at agnux's user directory

docker run -v ~/resources:/home/cfdiengine/resources -ti cfdiengine

The prior command allows to share the resources directory of agnux erp r1
between hoster and container

Signed-off-by: Bob Ross <pianodaemon@gmail.com>