### PR TITLE
cfdiengine: fixed bug as per resources symbolic link

### DIFF
--- a/cfdiengine/docmaker/builders/facxml.py
+++ b/cfdiengine/docmaker/builders/facxml.py
@@ -404,7 +404,7 @@ class FacXml(BuilderGen):
 
         conceptos = self.__q_conceptos(conn, prefact_id)
         retenciones = self.__calc_retenciones(conceptos,
-            self.__q_imptos_ret(self, conn, usr_id))
+            self.__q_imptos_ret(conn, usr_id))
         traslados = self.__calc_traslados(conceptos,
             self.__q_ieps(conn, usr_id), self.__q_ivas(conn))
 

--- a/tools/docker/cfdiengine/DockerFile
+++ b/tools/docker/cfdiengine/DockerFile
@@ -15,6 +15,7 @@ ENV GIT_REPO_CFDIENGINE https://github.com/gmas01/erp_sumar
 RUN git clone $GIT_REPO_CFDIENGINE last_clonation
 RUN mv ./last_clonation/cfdiengine ./
 RUN mkdir resources
+RUN ln -sf $PWD/resources $PWD/cfdiengine/
 RUN rm -rf ./last_clonation
 
 WORKDIR /home/cfdiengine/cfdiengine


### PR DESCRIPTION
As of now running in detached mode with the following command
that should be executed at agnux's user home.

docker run -v ~/resources:/home/cfdiengine/resources -dti cfdiengine

Signed-off-by: Bob Ross <pianodaemon@gmail.com>